### PR TITLE
fix town trader search by quest item

### DIFF
--- a/src/components/quests/quests.ts
+++ b/src/components/quests/quests.ts
@@ -118,7 +118,7 @@ function findItemShopRecursive(
             }
             findItemShopRecursive(itemId, shopType, towns, $, logger, success, error);
         })
-        .catch(() => error());
+        .catch(() => findItemShopRecursive(itemId, shopType, towns, $, logger, success, error));
 }
 
 function getTownsByDistance(towns: Record<number, Town>, map: Map, character: Character): Array<UserDistanceTown> {


### PR DESCRIPTION
If the current town doesn't have the trader built yet, it returns an error and stops searching without going through the remaining towns. Maybe you find a cleaner fix.