### PR TITLE
ci: modernize Actions (Node 24) and harden the deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
             - run: npm ci
             - uses: wagoid/commitlint-github-action@v6
               env:
@@ -28,10 +28,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
             - run: npm ci
             - run: npm run lint
             - run: npm run tsc
@@ -42,10 +42,10 @@ jobs:
         needs: lint
 
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
             - run: npm ci
             - run: npm run test
 
@@ -55,15 +55,15 @@ jobs:
         needs: test
 
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
             - run: npm ci
             - run: npm run build
               env:
                   CI: true
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v7
               with:
                   name: dist
                   path: dist
@@ -72,35 +72,16 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         runs-on: ubuntu-latest
         needs: build
+        permissions:
+            contents: write
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: 3.8
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v8
               with:
                   name: dist
-            - name: Prepare Release
-              run: |
-                  echo "USERSCRIPT_PATH=$(find . -type f -name '*.user.js')" >> $GITHUB_ENV
-                  echo "USERSCRIPT_NAME=$(find . -type f -name '*.user.js' -exec basename {} \;)" >> $GITHUB_ENV
-            - name: Create Release
-              id: create_release
-              uses: actions/create-release@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+                  path: dist
+            - name: Create draft release
+              uses: softprops/action-gh-release@v3
               with:
-                  tag_name: ${{ github.ref }}
-                  release_name: Release ${{ github.ref }}
                   draft: true
-                  prerelease: false
-            - name: Upload Release Asset (.user.js)
-              id: upload-release-asset-tar-gz
-              uses: actions/upload-release-asset@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  upload_url: ${{ steps.create_release.outputs.upload_url }}
-                  asset_path: ${{ env.USERSCRIPT_PATH }}
-                  asset_name: ${{ env.USERSCRIPT_NAME }}
-                  asset_content_type: application/javascript
+                  name: Release ${{ github.ref_name }}
+                  files: dist/*.user.js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,10 +9,10 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
             - name: Download release assets
               run: |
                   mkdir -p dist

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,12 +1,41 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 echo "Deploying on tw-calc.net..."
 
 VERSION="$(echo "$REF" | cut -d '/' -f3)"
 
-curl \
-  --form "apiKey=$TW_CALC_API_KEY" \
-  --form "version=$VERSION" \
-  --form "updateInfo=See <a href='https://github.com/The-West-Scripts/TW-Calc-Script/releases'>releases</a>." \
-  --form 'userscript=@./dist/TW_Calc.user.js' \
-  https://tw-calc.net/service/userscript-publish
+response_file="$(mktemp)"
+trap 'rm -f "$response_file"' EXIT
+
+# --fail-with-body makes curl exit non-zero on HTTP >= 400 while still capturing the
+# body, so a rejected publish can't masquerade as a successful (green) deploy.
+http_code="$(
+  curl \
+    --silent --show-error \
+    --fail-with-body \
+    --output "$response_file" \
+    --write-out '%{http_code}' \
+    --form "apiKey=$TW_CALC_API_KEY" \
+    --form "version=$VERSION" \
+    --form "updateInfo=See <a href='https://github.com/The-West-Scripts/TW-Calc-Script/releases'>releases</a>." \
+    --form 'userscript=@./dist/TW_Calc.user.js' \
+    https://tw-calc.net/service/userscript-publish
+)" || {
+  echo "::error::Publish request failed (HTTP ${http_code:-?})."
+  cat "$response_file"
+  exit 1
+}
+
+# The host (WEDOS Global Protection) can answer an automated request with an HTTP 200
+# anti-bot challenge page instead of running the publish — which previously looked like
+# a successful deploy. Treat a challenge/HTML response as a failure.
+if grep -qiE 'wedos|altcha|security verification|<!doctype html|<html' "$response_file"; then
+  echo "::error::Publish was intercepted by an anti-bot/challenge page instead of reaching the publish endpoint (HTTP ${http_code}). The script was NOT published."
+  echo "---- response (first 40 lines) ----"
+  head -n 40 "$response_file"
+  exit 1
+fi
+
+echo "Publish accepted (HTTP ${http_code}). Response:"
+cat "$response_file"


### PR DESCRIPTION
## Why

1. GitHub Actions runners now default the JS-action runtime to **Node 24** and warn on any action still declaring `node20` ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Node 20 itself is also EOL.
2. A v2.11.4 deploy revealed the publish step can **silently fail**: the host's anti-bot protection (WEDOS Global Protection) answered the CI `curl` with an HTTP 200 ALTCHA challenge page instead of running the publish, and the Deploy job still went green. The live script stayed on 2.11.3.

## What

**Standard actions → current node24 majors** (`ci.yml` + `deploy.yml`):
- `actions/checkout@v4 → @v7`
- `actions/setup-node@v4 → @v6`
- `actions/upload-artifact@v4 → @v7`
- `actions/download-artifact@v4 → @v8`
- build `node-version: 20 → 24` (matches local dev; no `engines`/`.nvmrc` pin)

**Release job — replace archived actions:**
`actions/create-release@v1` + `actions/upload-release-asset@v1` (Node 12, archived since 2020) → `softprops/action-gh-release@v3`, which:
- keeps `draft: true` (a human still edits notes + publishes — Deploy is unchanged),
- uploads `dist/*.user.js` directly, dropping the redundant `checkout` / `setup-python` / find-the-file steps,
- adds explicit `permissions: contents: write`.

**`ci/deploy.sh` — fail loudly:**
- `set -euo pipefail`
- `curl --fail-with-body` so HTTP >= 400 fails the job
- detect an intercepted challenge/HTML response (WEDOS/ALTCHA markers) and `exit 1` with a `::error::` annotation

> Note: this only makes a blocked deploy *visible*. The actual unblocking (a WEDOS bypass rule for `/service/userscript-publish`, or deploying off-WAF) is a server-side change handled separately.

## Validation

- YAML parses; non-release jobs (commitlint/lint/test/build) pass on this PR's CI run with **no deprecation annotations**.
- `deploy.sh`: `bash -n` clean; challenge-detection verified to flag the WEDOS/ALTCHA page and pass JSON/plain-text responses.
- ⚠️ The **release** job and **deploy** run only on tags / published releases, so the `softprops` swap and the deploy hardening can't be fully exercised until the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)